### PR TITLE
Feature/sample data utils

### DIFF
--- a/config.js
+++ b/config.js
@@ -6,10 +6,10 @@ module.exports = {
   PORT: process.env.PORT || 8080,
   CLIENT_ORIGIN: process.env.CLIENT_ORIGIN || 'http://localhost:3000',
   DATABASE_URL:
-        process.env.DATABASE_URL || 'mongodb://localhost/shaving',
+        process.env.DATABASE_URL || 'mongodb://localhost:27017/shaving',
   TEST_DATABASE_URL:
         process.env.TEST_DATABASE_URL ||
-        'mongodb://localhost/shaving-test',
+        'mongodb://localhost:27017/shaving-test',
   JWT_SECRET: process.env.JWT_SECRET,
   JWT_EXPIRY: process.env.JWT_EXPIRY || '7d'
   // DATABASE_URL:

--- a/db/seed/products.json
+++ b/db/seed/products.json
@@ -1,0 +1,268 @@
+[
+  {
+    "_id": "222222222222222222222000",
+    "type": "Double Edge",
+    "productType": "razor",
+    "brand": "Gillette",
+    "model": "Tech Travel"
+  },
+  {
+    "_id": "222222222222222222222001",
+    "type": "Double Edge",
+    "productType": "razor",
+    "brand": "Above the Tie",
+    "model": "Calypso R1"
+  },
+  {
+    "_id": "222222222222222222222002",
+    "type": "Double Edge",
+    "productType": "razor",
+    "brand": "Merkur",
+    "model": "34c"
+  },
+  {
+    "_id": "222222222222222222222003",
+    "type": "Double Edge",
+    "productType": "razor",
+    "brand": "Rockwell",
+    "model": "6S"
+  },
+  {
+    "_id": "222222222222222222222004",
+    "type": "Double Edge",
+    "productType": "razor",
+    "brand": "Above the Tie",
+    "model": "Calypso M1"
+  },
+  {
+    "_id": "222222222222222222222005",
+    "type": "Straight",
+    "productType": "razor",
+    "brand": "Globusmen",
+    "model": "Gold No.46"
+  },
+  {
+    "_id": "222222222222222222222006",
+    "type": "Double Edge",
+    "productType": "razor",
+    "brand": "Muhle",
+    "model": "R108 Tortoise Shell"
+  },
+  {
+    "_id": "222222222222222222222007",
+    "type": null,
+    "productType": "blade",
+    "brand": "Gillette",
+    "model": "Wilkinson"
+  },
+  {
+    "_id": "222222222222222222222008",
+    "type": null,
+    "productType": "blade",
+    "brand": "Gillette",
+    "model": "Silver Blue"
+  },
+  {
+    "_id": "222222222222222222222009",
+    "type": null,
+    "productType": "blade",
+    "brand": "Feather",
+    "model": "Hi-STAINLESS"
+  },
+  {
+    "_id": "222222222222222222222010",
+    "type": null,
+    "productType": "blade",
+    "brand": "Astra",
+    "model": "Superior Platinum"
+  },
+  {
+    "_id": "222222222222222222222011",
+    "type": null,
+    "productType": "blade",
+    "brand": "Gillette",
+    "model": "7 O'Clock SharpEdge"
+  },
+  {
+    "_id": "222222222222222222222012",
+    "type": null,
+    "productType": "blade",
+    "brand": "Polsilver",
+    "model": "Super Iridium"
+  },
+  {
+    "_id": "222222222222222222222013",
+    "type": "Boar",
+    "productType": "brush",
+    "brand": "Surrey",
+    "model": "34014 Deluxe"
+  },
+  {
+    "_id": "222222222222222222222014",
+    "type": "Boar",
+    "productType": "brush",
+    "brand": "Semogue",
+    "model": "Brushbutt 22mm"
+  },
+  {
+    "_id": "222222222222222222222015",
+    "type": "Synthetic",
+    "productType": "brush",
+    "brand": "RazoRock",
+    "model": "Plissoft Monster"
+  },
+  {
+    "_id": "222222222222222222222016",
+    "type": "Synthetic",
+    "productType": "brush",
+    "brand": "Turtleship Shave Co",
+    "model": "Admiral Blue"
+  },
+  {
+    "_id": "222222222222222222222017",
+    "type": "Badger",
+    "productType": "brush",
+    "brand": "Kent",
+    "model": "BK8"
+  },
+  {
+    "_id": "222222222222222222222018",
+    "type": "Badger",
+    "productType": "brush",
+    "brand": "Stirling Soap Company",
+    "model": "Finest Badger Shave Brush"
+  },
+  {
+    "_id": "222222222222222222222019",
+    "type": "Soap",
+    "productType": "lather",
+    "brand": "Stirling Soap Company",
+    "model": "Barbershop"
+  },
+  {
+    "_id": "222222222222222222222020",
+    "type": "Cream",
+    "productType": "lather",
+    "brand": "L\"Occitane",
+    "model": "Cade"
+  },
+  {
+    "_id": "222222222222222222222021",
+    "type": "Soap",
+    "productType": "lather",
+    "brand": "Chiseled Face",
+    "model": "Cryogen"
+  },
+  {
+    "_id": "222222222222222222222022",
+    "type": "Soap",
+    "productType": "lather",
+    "brand": "Barrister and Mann",
+    "model": "Lavanille"
+  },
+  {
+    "_id": "222222222222222222222023",
+    "type": "Soap",
+    "productType": "lather",
+    "brand": "Barrister and Mann",
+    "model": "Leviathan"
+  },
+  {
+    "_id": "222222222222222222222024",
+    "type": "Cream",
+    "productType": "lather",
+    "brand": "Proraso",
+    "model": "Green"
+  },
+  {
+    "_id": "222222222222222222222025",
+    "type": "Cream",
+    "productType": "lather",
+    "brand": "Above the Tie",
+    "model": "Lavendar & Lemonade"
+  },
+  {
+    "_id": "222222222222222222222026",
+    "type": "Soap",
+    "productType": "lather",
+    "brand": "Barrister and Mann",
+    "model": "Roam"
+  },
+  {
+    "_id": "222222222222222222222027",
+    "type": "Soap",
+    "productType": "lather",
+    "brand": "Black Ship Grooming",
+    "model": "Captain Joe"
+  },
+  {
+    "_id": "222222222222222222222028",
+    "type": "Soap",
+    "productType": "lather",
+    "brand": "Declaration Grooming",
+    "model": "Reserve Lavender"
+  },
+  {
+    "_id": "222222222222222222222029",
+    "type": "Splash",
+    "productType": "aftershave",
+    "brand": "Brut",
+    "model": "Classic"
+  },
+  {
+    "_id": "222222222222222222222030",
+    "type": "Splash",
+    "productType": "aftershave",
+    "brand": "Chatillon Lux",
+    "model": "Taum Sauk"
+  },
+  {
+    "_id": "222222222222222222222031",
+    "type": "Splash",
+    "productType": "aftershave",
+    "brand": "Barrister and Mann",
+    "model": "Lavanille"
+  },
+  {
+    "_id": "222222222222222222222032",
+    "type": "Splash",
+    "productType": "aftershave",
+    "brand": "Barrister and Mann",
+    "model": "Leviathan"
+  },
+  {
+    "_id": "222222222222222222222033",
+    "type": "Balm",
+    "productType": "aftershave",
+    "brand": "Stirling Soap Company",
+    "model": "Sandalwood"
+  },
+  {
+    "_id": "222222222222222222222034",
+    "type": "Balm",
+    "productType": "aftershave",
+    "brand": "Black Ship Grooming",
+    "model": "Captain Joe"
+  },
+  {
+    "_id": "222222222222222222222035",
+    "type": null,
+    "productType": "additionalcare",
+    "brand": "Proraso",
+    "model": "Green"
+  },
+  {
+    "_id": "222222222222222222222036",
+    "type": null,
+    "productType": "additionalcare",
+    "brand": "Thayers",
+    "model": "Witch Hazel"
+  },
+  {
+    "_id": "222222222222222222222037",
+    "type": null,
+    "productType": "additionalcare",
+    "brand": "Stirling Soap Company",
+    "model": "Red Delicious - Bath Soap"
+  }
+]

--- a/db/seed/shaves.json
+++ b/db/seed/shaves.json
@@ -1,13 +1,74 @@
 [
   {
-    userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
-    razorId: { type: mongoose.Schema.Types.ObjectId, ref: 'Product' },
-    bladeId: { type: mongoose.Schema.Types.ObjectId, ref: 'Product' },
-    brushId: { type: mongoose.Schema.Types.ObjectId, ref: 'Product' },
-    latherId: { type: mongoose.Schema.Types.ObjectId, ref: 'Product' },
-    aftershaveId: { type: mongoose.Schema.Types.ObjectId, ref: 'Product' },
-    additionalCare: { type: mongoose.Schema.Types.ObjectId, ref: 'Product' },
-    rating: Number,
-    date: { type:Date, required:true }
+    "_id": "555555555555555555555000",
+    "userId": "333333333333333333333300",
+    "razorId": "444444444444444444444000",
+    "bladeId": "444444444444444444444003",
+    "brushId": "444444444444444444444007",
+    "latherId": "444444444444444444444009",
+    "aftershaveId": "444444444444444444444012",
+    "additionalCareId": "444444444444444444444014",
+    "rating": "4",
+    "date": "2018-09-21"
+  },
+  {
+    "_id": "555555555555555555555001",
+    "userId": "333333333333333333333300",
+    "razorId": "444444444444444444444001",
+    "bladeId": "444444444444444444444004",
+    "brushId": "444444444444444444444008",
+    "latherId": "444444444444444444444010",
+    "aftershaveId": "444444444444444444444013",
+    "additionalCareId": null,
+    "rating": "5",
+    "date": "2018-09-24"
+  },
+  {
+    "_id": "555555555555555555555002",
+    "userId": "333333333333333333333301",
+    "razorId": "444444444444444444444015",
+    "bladeId": "444444444444444444444018",
+    "brushId": "444444444444444444444022",
+    "latherId": "444444444444444444444024",
+    "aftershaveId": "444444444444444444444027",
+    "additionalCareId": "444444444444444444444029",
+    "rating": "4",
+    "date": "2018-09-21"
+  },
+  {
+    "_id": "555555555555555555555003",
+    "userId": "333333333333333333333301",
+    "razorId": "444444444444444444444016",
+    "bladeId": "444444444444444444444019",
+    "brushId": "444444444444444444444023",
+    "latherId": "444444444444444444444025",
+    "aftershaveId": "444444444444444444444028",
+    "additionalCareId": "444444444444444444444030",
+    "rating": "3",
+    "date": "2018-09-24"
+  },
+  {
+    "_id": "555555555555555555555004",
+    "userId": "333333333333333333333302",
+    "razorId": "444444444444444444444031",
+    "bladeId": "444444444444444444444034",
+    "brushId": "444444444444444444444039",
+    "latherId": "444444444444444444444041",
+    "aftershaveId": "444444444444444444444045",
+    "additionalCareId": "444444444444444444444047",
+    "rating": "4",
+    "date": "2018-09-21"
+  },
+  {
+    "_id": "555555555555555555555005",
+    "userId": "333333333333333333333302",
+    "razorId": "444444444444444444444032",
+    "bladeId": "444444444444444444444037",
+    "brushId": "444444444444444444444040",
+    "latherId": "444444444444444444444043",
+    "aftershaveId": "444444444444444444444046",
+    "additionalCareId": "444444444444444444444047",
+    "rating": "3",
+    "date": "2018-09-24"
   }
 ]

--- a/db/seed/shaves.json
+++ b/db/seed/shaves.json
@@ -1,0 +1,13 @@
+[
+  {
+    userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+    razorId: { type: mongoose.Schema.Types.ObjectId, ref: 'Product' },
+    bladeId: { type: mongoose.Schema.Types.ObjectId, ref: 'Product' },
+    brushId: { type: mongoose.Schema.Types.ObjectId, ref: 'Product' },
+    latherId: { type: mongoose.Schema.Types.ObjectId, ref: 'Product' },
+    aftershaveId: { type: mongoose.Schema.Types.ObjectId, ref: 'Product' },
+    additionalCare: { type: mongoose.Schema.Types.ObjectId, ref: 'Product' },
+    rating: Number,
+    date: { type:Date, required:true }
+  }
+]

--- a/db/seed/user-products.json
+++ b/db/seed/user-products.json
@@ -1,0 +1,335 @@
+[
+  {
+    "userId": "333333333333333333333300",
+    "razors": [
+      {
+        "_id": "444444444444444444444000",
+        "productId": "222222222222222222222000",
+        "comment": "1964 vintage",
+        "nickname": "Gillette Tech Travel"
+      },
+      {
+        "_id": "444444444444444444444001",
+        "productId": "222222222222222222222003",
+        "comment": "R5",
+        "nickname": "Rockwell 6S R5"
+      },
+      {
+        "_id": "444444444444444444444002",
+        "productId": "222222222222222222222006",
+        "comment": "closed comb",
+        "nickname": "Muhle Tortoise"
+      }
+    ],
+    "blades": [
+      {
+        "_id": "444444444444444444444003",
+        "productId": "222222222222222222222007",
+        "comment": "",
+        "nickname": "Gillette Wilkinson"
+      },
+      {
+        "_id": "444444444444444444444004",
+        "productId": "222222222222222222222008",
+        "comment": "",
+        "nickname": "Gillette Silver Blue"
+      },
+      {
+        "_id": "444444444444444444444005",
+        "productId": "222222222222222222222010",
+        "comment": "",
+        "nickname": "Astra SP"
+      },
+      {
+        "_id": "444444444444444444444006",
+        "productId": "222222222222222222222011",
+        "comment": "",
+        "nickname": "Gillette 7 O'Clock"
+      }
+    ],
+    "brushes": [
+      {
+        "_id": "444444444444444444444007",
+        "productId": "222222222222222222222013",
+        "comment": "",
+        "nickname": "Surrey 34014 Deluxe"
+      },
+      {
+        "_id": "444444444444444444444008",
+        "productId": "222222222222222222222016",
+        "comment": "24mm",
+        "nickname": "TSC Admiral Blue 24mm"
+      }
+    ],
+    "lathers": [
+      {
+        "_id": "444444444444444444444009",
+        "productId": "222222222222222222222019",
+        "comment": "",
+        "nickname": "Stirling's Barbershop"
+      },
+      {
+        "_id": "444444444444444444444010",
+        "productId": "222222222222222222222020",
+        "comment": "",
+        "nickname": "L'Occitane Cade Rich"
+      },
+      {
+        "_id": "444444444444444444444011",
+        "productId": "222222222222222222222021",
+        "comment": "sampler",
+        "nickname": "Chiseled Face Cryogen"
+      }
+    ],
+    "aftershaves": [
+      {
+        "_id": "444444444444444444444012",
+        "productId": "222222222222222222222029",
+        "comment": "",
+        "nickname": "Brut Classic"
+      },
+      {
+        "_id": "444444444444444444444013",
+        "productId": "222222222222222222222030",
+        "comment": "",
+        "nickname": "CL-Taum Sauk"
+      }
+    ],
+    "additionalcares": [
+      {
+        "_id": "444444444444444444444014",
+        "productId": "222222222222222222222035",
+        "comment": "",
+        "nickname": "Proraso Green"
+      }
+    ]
+  },
+  {
+    "userId": "333333333333333333333301",
+    "razors": [
+      {
+        "_id": "444444444444444444444015",
+        "productId": "222222222222222222222001",
+        "comment": "",
+        "nickname": "ATT Calypso R1"
+      },
+      {
+        "_id": "444444444444444444444016",
+        "productId": "222222222222222222222002",
+        "comment": "long-handled",
+        "nickname": "Merkur 34c"
+      },
+      {
+        "_id": "444444444444444444444017",
+        "productId": "222222222222222222222004",
+        "comment": "",
+        "nickname": "ATT Calypso M1"
+      }
+    ],
+    "blades": [
+      {
+        "_id": "444444444444444444444018",
+        "productId": "222222222222222222222008",
+        "comment": "",
+        "nickname": "GSB"
+      },
+      {
+        "_id": "444444444444444444444019",
+        "productId": "222222222222222222222009",
+        "comment": "wicked sharp!",
+        "nickname": "Feather"
+      },
+      {
+        "_id": "444444444444444444444020",
+        "productId": "222222222222222222222010",
+        "comment": "",
+        "nickname": "Astra SP"
+      },
+      {
+        "_id": "444444444444444444444021",
+        "productId": "222222222222222222222011",
+        "comment": "tugs a little, not as smooth as I hoped",
+        "nickname": "7 O'Clock Sharps"
+      }
+    ],
+    "brushes": [
+      {
+        "_id": "444444444444444444444022",
+        "productId": "222222222222222222222014",
+        "comment": "Limited Edition #78/100",
+        "nickname": "Brushbutt LE"
+      },
+      {
+        "_id": "444444444444444444444023",
+        "productId": "222222222222222222222017",
+        "comment": "",
+        "nickname": "Kent BK8"
+      }
+    ],
+    "lathers": [
+      {
+        "_id": "444444444444444444444024",
+        "productId": "222222222222222222222022",
+        "comment": "tre Citta Line",
+        "nickname": "B&M Lavanille"
+      },
+      {
+        "_id": "444444444444444444444025",
+        "productId": "222222222222222222222023",
+        "comment": "leather | coffee | sandalwood",
+        "nickname": "B&M Leviathan"
+      },
+      {
+        "_id": "444444444444444444444026",
+        "productId": "222222222222222222222024",
+        "comment": "horrible, no slickness",
+        "nickname": "Proraso Green"
+      }
+    ],
+    "aftershaves": [
+      {
+        "_id": "444444444444444444444027",
+        "productId": "222222222222222222222031",
+        "comment": "",
+        "nickname": "Lavanille Splash"
+      },
+      {
+        "_id": "444444444444444444444028",
+        "productId": "222222222222222222222032",
+        "comment": "",
+        "nickname": "Leviathan Splash"
+      }
+    ],
+    "additionalcares": [
+      {
+        "_id": "444444444444444444444029",
+        "productId": "222222222222222222222036",
+        "comment": "",
+        "nickname": "Thayers Witch Hazel"
+      },
+      {
+        "_id": "444444444444444444444030",
+        "productId": "222222222222222222222037",
+        "comment": "",
+        "nickname": "Stirling Red Delicious Bath Soap"
+      }
+    ]
+  },
+  {
+    "userId": "333333333333333333333302",
+    "razors": [
+      {
+        "_id": "444444444444444444444031",
+        "productId": "222222222222222222222002",
+        "comment": "",
+        "nickname": "Merkur 34c"
+      },
+      {
+        "_id": "444444444444444444444032",
+        "productId": "222222222222222222222005",
+        "comment": "vintage German-made blade",
+        "nickname": "Globusmen Straight"
+      },
+      {
+        "_id": "444444444444444444444033",
+        "productId": "222222222222222222222006",
+        "comment": "Tortoise shell handle",
+        "nickname": "The Turtle"
+      }
+    ],
+    "blades": [
+      {
+        "_id": "444444444444444444444034",
+        "productId": "222222222222222222222008",
+        "comment": "",
+        "nickname": "Silver Blues"
+      },
+      {
+        "_id": "444444444444444444444035",
+        "productId": "222222222222222222222009",
+        "comment": "too sharp, very aggressive",
+        "nickname": "Feather"
+      },
+      {
+        "_id": "444444444444444444444036",
+        "productId": "222222222222222222222010",
+        "comment": "smooth like butter",
+        "nickname": "Astra Platinums"
+      },
+      {
+        "_id": "444444444444444444444037",
+        "productId": "222222222222222222222011",
+        "comment": "2nd favorite",
+        "nickname": "Gillette 7's"
+      },
+      {
+        "_id": "444444444444444444444038",
+        "productId": "222222222222222222222012",
+        "comment": "",
+        "nickname": "Polsilver - Super Iridium"
+      }
+    ],
+    "brushes": [
+      {
+        "_id": "444444444444444444444039",
+        "productId": "222222222222222222222015",
+        "comment": "",
+        "nickname": "RazoRock Plissoft Monster"
+      },
+      {
+        "_id": "444444444444444444444040",
+        "productId": "222222222222222222222018",
+        "comment": "26mm",
+        "nickname": "Stirling Badger"
+      }
+    ],
+    "lathers": [
+      {
+        "_id": "444444444444444444444041",
+        "productId": "222222222222222222222025",
+        "comment": "awesome",
+        "nickname": "ATT Lemonade"
+      },
+      {
+        "_id": "444444444444444444444042",
+        "productId": "222222222222222222222026",
+        "comment": "Tobacco | Thyme | Grass | Damp Earth | Wood Smoke",
+        "nickname": "B&M Roam"
+      },
+      {
+        "_id": "444444444444444444444043",
+        "productId": "222222222222222222222027",
+        "comment": "",
+        "nickname": "Black Ship Grooming Captain Joe"
+      },
+      {
+        "_id": "444444444444444444444044",
+        "productId": "222222222222222222222028",
+        "comment": "",
+        "nickname": "Declaration Grooming - Reserve Lavender"
+      }
+    ],
+    "aftershaves": [
+      {
+        "_id": "444444444444444444444045",
+        "productId": "222222222222222222222033",
+        "comment": "",
+        "nickname": "Stirling Sandalwood Balm"
+      },
+      {
+        "_id": "444444444444444444444046",
+        "productId": "222222222222222222222034",
+        "comment": "",
+        "nickname": "Black Ship Grooming Captain Joe"
+      }
+    ],
+    "additionalcares": [
+      {
+        "_id": "444444444444444444444047",
+        "productId": "222222222222222222222036",
+        "comment": "",
+        "nickname": "Thayers Witch Hazel"
+      }
+    ]
+  }
+]

--- a/db/seed/users.json
+++ b/db/seed/users.json
@@ -1,0 +1,20 @@
+[
+  {
+    "_id": "333333333333333333333300",
+    "username": "bobuser",
+    "email": "bob@example.com",
+    "password": "$2a$10$iJSPFD5uhrPiefsOn0dNdOCsLu7VomReinsFtZzZcMZYylsYM3She"
+  },
+  {
+    "_id": "333333333333333333333301",
+    "username": "patuser",
+    "email": "pat@example.com",
+    "password": "$2a$10$iJSPFD5uhrPiefsOn0dNdOCsLu7VomReinsFtZzZcMZYylsYM3She"
+  },
+  {
+    "_id": "333333333333333333333302",
+    "username": "janeuser",
+    "email": "jane@example.com",
+    "password": "$2a$10$iJSPFD5uhrPiefsOn0dNdOCsLu7VomReinsFtZzZcMZYylsYM3She"
+  }
+]

--- a/db/seed/users.json
+++ b/db/seed/users.json
@@ -1,20 +1,20 @@
 [
   {
     "_id": "333333333333333333333300",
-    "username": "bobuser",
-    "email": "bob@example.com",
-    "password": "$2a$10$iJSPFD5uhrPiefsOn0dNdOCsLu7VomReinsFtZzZcMZYylsYM3She"
+    "username": "beardy",
+    "email": "beardy@example.com",
+    "password": "$2a$10$d94B1zkuErVnVfE24n.C2uMHXB8aP9oLBcGjecv240U3oYD4V2yii"
   },
   {
     "_id": "333333333333333333333301",
-    "username": "patuser",
-    "email": "pat@example.com",
-    "password": "$2a$10$iJSPFD5uhrPiefsOn0dNdOCsLu7VomReinsFtZzZcMZYylsYM3She"
+    "username": "smooth",
+    "email": "smooth@example.com",
+    "password": "$2a$10$d94B1zkuErVnVfE24n.C2uMHXB8aP9oLBcGjecv240U3oYD4V2yii"
   },
   {
     "_id": "333333333333333333333302",
-    "username": "janeuser",
-    "email": "jane@example.com",
-    "password": "$2a$10$iJSPFD5uhrPiefsOn0dNdOCsLu7VomReinsFtZzZcMZYylsYM3She"
+    "username": "hipster",
+    "email": "hipster@example.com",
+    "password": "$2a$10$d94B1zkuErVnVfE24n.C2uMHXB8aP9oLBcGjecv240U3oYD4V2yii"
   }
 ]

--- a/documentation/sampleData.js
+++ b/documentation/sampleData.js
@@ -1,0 +1,397 @@
+'use strict';
+
+const sampleData = {
+  userId: 123456789012,
+  razors: [
+    {
+      productId: {
+        type: 'Double Edge',
+        productType: 'razor',
+        brand: 'Gillette',
+        model: 'Tech Travel',
+      },
+      comment: '1964 vintage',
+      nickname: 'Gillette Tech Travel'
+    },
+    {
+      productId: {
+        type: 'Double Edge',
+        productType: 'razor',
+        brand: 'Above the Tie',
+        model: 'Calypso R1',
+      },
+      comment: '',
+      nickname: 'ATT Calypso R1'
+    },
+    {
+      productId: {
+        type: 'Double Edge',
+        productType: 'razor',
+        brand: 'Merkur',
+        model: '34c',
+      },
+      comment: '',
+      nickname: 'Merkur 34c'
+    },
+    {
+      productId: {
+        type: 'Double Edge',
+        productType: 'razor',
+        brand: 'Rockwell',
+        model: '6S',
+      },
+      comment: 'R5',
+      nickname: 'Rockwell 6S R5'
+    },
+    {
+      productId: {
+        type: 'Double Edge',
+        productType: 'razor',
+        brand: 'Above the Tie',
+        model: 'Calypso M1',
+      },
+      comment: '',
+      nickname: 'ATT Calypso M1'
+    },
+    {
+      productId: {
+        type: 'Straight',
+        productType: 'razor',
+        brand: 'Globusmen',
+        model: 'Gold No.46',
+      },
+      comment: 'vintage German-made blade',
+      nickname: 'Globusmen Straight'
+    },
+    {
+      productId: {
+        type: 'Double Edge',
+        productType: 'razor',
+        brand: 'Muhle',
+        model: 'R108 Tortoise Shell',
+      },
+      comment: 'closed comb',
+      nickname: 'Muhle Tortoise'
+    },
+  ],
+  blades: [
+    {
+      productId: {
+        type: null,
+        productType: 'blade',
+        brand: 'Gillette',
+        model: 'Wilkinson',
+      },
+      comment: '',
+      nickname: 'Gillette Wilkinson'
+    },
+    {
+      productId: {
+        type: null,
+        productType: 'blade',
+        brand: 'Gillette',
+        model: 'Silver Blue',
+      },
+      comment: '',
+      nickname: 'GSB'
+    },
+    {
+      productId: {
+        type: null,
+        productType: 'blade',
+        brand: 'Feather',
+        model: 'Hi-STAINLESS',
+      },
+      comment: '',
+      nickname: 'Feather'
+    },
+    {
+      productId: {
+        type: null,
+        productType: 'blade',
+        brand: 'Astra',
+        model: 'Superior Platinum',
+      },
+      comment: '',
+      nickname: 'Astra SP'
+    },
+    {
+      productId: {
+        type: null,
+        productType: 'blade',
+        brand: 'Gillette',
+        model: '7 O\'Clock SharpEdge',
+      },
+      comment: '',
+      nickname: 'Gillette 7 O\'Clock'
+    },
+    {
+      productId: {
+        type: null,
+        productType: 'blade',
+        brand: 'Polsilver',
+        model: 'Super Iridium',
+      },
+      comment: '',
+      nickname: 'Polsilver - Super Iridium'
+    },
+  ],
+  brushes: [
+    {
+      productId: {
+        type: 'Boar',
+        productType: 'brush',
+        brand: 'Surrey',
+        model: '34014 Deluxe',
+      },
+      comment: '',
+      nickname: 'Surrey 34014 Deluxe'
+    },
+    {
+      productId: {
+        type: 'Boar',
+        productType: 'brush',
+        brand: 'Semogue',
+        model: 'Brushbutt 22mm',
+      },
+      comment: 'Limited Edition #78/100',
+      nickname: 'Brushbutt LE'
+    },
+    {
+      productId: {
+        type: 'Synthetic',
+        productType: 'brush',
+        brand: 'RazoRock',
+        model: 'Plissoft Monster',
+      },
+      comment: '',
+      nickname: 'RazoRock Plissoft Monster'
+    },
+    {
+      productId: {
+        type: 'Synthetic',
+        productType: 'brush',
+        brand: 'Turtleship Shave Co',
+        model: 'Admiral Blue',
+      },
+      comment: '24mm',
+      nickname: 'TSC Admiral Blue 24mm'
+    },
+    {
+      productId: {
+        type: 'Badger',
+        productType: 'brush',
+        brand: 'Kent',
+        model: 'BK8',
+      },
+      comment: '',
+      nickname: 'Kent BK8'
+    },
+    {
+      productId: {
+        type: 'Badger',
+        productType: 'brush',
+        brand: 'Stirling Soap Company',
+        model: 'Finest Badger Shave Brush',
+      },
+      comment: '26mm',
+      nickname: 'Stirling Badger'
+    },
+  ],
+  lathers: [
+    {
+      productId: {
+        type: 'Soap',
+        productType: 'lather',
+        brand: 'Stirling Soap Company',
+        model: 'Barbershop',
+      },
+      comment: '',
+      nickname: 'Stirling\'s Barbershop'
+    },
+    {
+      productId: {
+        type: 'Cream',
+        productType: 'lather',
+        brand: 'L\'Occitane',
+        model: 'Cade',
+      },
+      comment: '',
+      nickname: 'L\'Occitane Cade Rich'
+    },
+    {
+      productId: {
+        type: 'Soap',
+        productType: 'lather',
+        brand: 'Chiseled Face',
+        model: 'Cryogen',
+      },
+      comment: 'sampler',
+      nickname: 'Chiseled Face Cryogen'
+    },
+    {
+      productId: {
+        type: 'Soap',
+        productType: 'lather',
+        brand: 'Barrister and Mann',
+        model: 'Lavanille',
+      },
+      comment: 'tre Citta Line',
+      nickname: 'B&M Lavanille'
+    },
+    {
+      productId: {
+        type: 'Soap',
+        productType: 'lather',
+        brand: 'Barrister and Mann',
+        model: 'Leviathan',
+      },
+      comment: 'leather | coffee | sandalwood',
+      nickname: 'B&M Leviathan'
+    },
+    {
+      productId: {
+        type: 'Cream',
+        productType: 'lather',
+        brand: 'Proraso',
+        model: 'Green',
+      },
+      comment: 'horrible, no slickness',
+      nickname: 'Proraso Green'
+    },
+    {
+      productId: {
+        type: 'Cream',
+        productType: 'lather',
+        brand: 'Above the Tie',
+        model: 'Lavendar & Lemonade',
+      },
+      comment: 'awesome',
+      nickname: 'ATT Lemonade'
+    },
+    {
+      productId: {
+        type: 'Soap',
+        productType: 'lather',
+        brand: 'Barrister and Mann',
+        model: 'Roam',
+      },
+      comment: 'Tobacco | Thyme | Grass | Damp Earth | Wood Smoke',
+      nickname: 'B&M Roam'
+    },
+    {
+      productId: {
+        type: 'Soap',
+        productType: 'lather',
+        brand: 'Black Ship Grooming',
+        model: 'Captain Joe',
+      },
+      comment: '',
+      nickname: 'Black Ship Grooming Captain Joe'
+    },
+    {
+      productId: {
+        type: 'Soap',
+        productType: 'lather',
+        brand: 'Declaration Grooming',
+        model: 'Reserve Lavender',
+      },
+      comment: '',
+      nickname: 'Declaration Grooming - Reserve Lavender'
+    },
+  ],
+  aftershaves: [
+    {
+      productId: {
+        type: 'Splash',
+        productType: 'aftershave',
+        brand: 'Brut',
+        model: 'Classic',
+      },
+      comment: '',
+      nickname: 'Brut Classic'
+    },
+    {
+      productId: {
+        type: 'Splash',
+        productType: 'aftershave',
+        brand: 'Chatillon Lux',
+        model: 'Taum Sauk',
+      },
+      comment: '',
+      nickname: 'CL-Taum Sauk'
+    },
+    {
+      productId: {
+        type: 'Splash',
+        productType: 'aftershave',
+        brand: 'Barrister and Mann',
+        model: 'Lavanille',
+      },
+      comment: '',
+      nickname: 'Lavanille Splash'
+    },
+    {
+      productId: {
+        type: 'Splash',
+        productType: 'aftershave',
+        brand: 'Barrister and Mann',
+        model: 'Leviathan',
+      },
+      comment: '',
+      nickname: 'Leviathan Splash'
+    },
+    {
+      productId: {
+        type: 'Balm',
+        productType: 'aftershave',
+        brand: 'Stirling Soap Company',
+        model: 'Sandalwood',
+      },
+      comment: '',
+      nickname: 'Stirling Sandalwood Balm'
+    },
+    {
+      productId: {
+        type: 'Balm',
+        productType: 'aftershave',
+        brand: 'Black Ship Grooming',
+        model: 'Captain Joe',
+      },
+      comment: '',
+      nickname: 'Black Ship Grooming Captain Joe'
+    },
+  ],
+  additionalcares: [
+    {
+      productId: {
+        type: null,
+        productType: 'additionalcare',
+        brand: 'Proraso',
+        model: 'Green',
+      },
+      comment: '',
+      nickname: 'Proraso Green'
+    },
+    {
+      productId: {
+        type: null,
+        productType: 'additionalcare',
+        brand: 'Thayers',
+        model: 'Witch Hazel',
+      },
+      comment: '',
+      nickname: 'Thayers Witch Hazel'
+    },
+    {
+      productId: {
+        type: null,
+        productType: 'additionalcare',
+        brand: 'Stirling Soap Company',
+        model: 'Red Delicious - Bath Soap',
+      },
+      comment: '',
+      nickname: 'Stirling Red Delicious Bath Soap'
+    },
+  ]
+};

--- a/documentation/sampleData.js
+++ b/documentation/sampleData.js
@@ -8,7 +8,7 @@ const sampleData = {
         type: 'Double Edge',
         productType: 'razor',
         brand: 'Gillette',
-        model: 'Tech Travel',
+        model: 'Tech Travel'
       },
       comment: '1964 vintage',
       nickname: 'Gillette Tech Travel'
@@ -18,7 +18,7 @@ const sampleData = {
         type: 'Double Edge',
         productType: 'razor',
         brand: 'Above the Tie',
-        model: 'Calypso R1',
+        model: 'Calypso R1'
       },
       comment: '',
       nickname: 'ATT Calypso R1'
@@ -28,7 +28,7 @@ const sampleData = {
         type: 'Double Edge',
         productType: 'razor',
         brand: 'Merkur',
-        model: '34c',
+        model: '34c'
       },
       comment: '',
       nickname: 'Merkur 34c'
@@ -38,7 +38,7 @@ const sampleData = {
         type: 'Double Edge',
         productType: 'razor',
         brand: 'Rockwell',
-        model: '6S',
+        model: '6S'
       },
       comment: 'R5',
       nickname: 'Rockwell 6S R5'
@@ -48,7 +48,7 @@ const sampleData = {
         type: 'Double Edge',
         productType: 'razor',
         brand: 'Above the Tie',
-        model: 'Calypso M1',
+        model: 'Calypso M1'
       },
       comment: '',
       nickname: 'ATT Calypso M1'
@@ -58,7 +58,7 @@ const sampleData = {
         type: 'Straight',
         productType: 'razor',
         brand: 'Globusmen',
-        model: 'Gold No.46',
+        model: 'Gold No.46'
       },
       comment: 'vintage German-made blade',
       nickname: 'Globusmen Straight'
@@ -68,7 +68,7 @@ const sampleData = {
         type: 'Double Edge',
         productType: 'razor',
         brand: 'Muhle',
-        model: 'R108 Tortoise Shell',
+        model: 'R108 Tortoise Shell'
       },
       comment: 'closed comb',
       nickname: 'Muhle Tortoise'
@@ -80,7 +80,7 @@ const sampleData = {
         type: null,
         productType: 'blade',
         brand: 'Gillette',
-        model: 'Wilkinson',
+        model: 'Wilkinson'
       },
       comment: '',
       nickname: 'Gillette Wilkinson'
@@ -90,7 +90,7 @@ const sampleData = {
         type: null,
         productType: 'blade',
         brand: 'Gillette',
-        model: 'Silver Blue',
+        model: 'Silver Blue'
       },
       comment: '',
       nickname: 'GSB'
@@ -100,7 +100,7 @@ const sampleData = {
         type: null,
         productType: 'blade',
         brand: 'Feather',
-        model: 'Hi-STAINLESS',
+        model: 'Hi-STAINLESS'
       },
       comment: '',
       nickname: 'Feather'
@@ -110,7 +110,7 @@ const sampleData = {
         type: null,
         productType: 'blade',
         brand: 'Astra',
-        model: 'Superior Platinum',
+        model: 'Superior Platinum'
       },
       comment: '',
       nickname: 'Astra SP'
@@ -120,7 +120,7 @@ const sampleData = {
         type: null,
         productType: 'blade',
         brand: 'Gillette',
-        model: '7 O\'Clock SharpEdge',
+        model: '7 O\'Clock SharpEdge'
       },
       comment: '',
       nickname: 'Gillette 7 O\'Clock'
@@ -130,7 +130,7 @@ const sampleData = {
         type: null,
         productType: 'blade',
         brand: 'Polsilver',
-        model: 'Super Iridium',
+        model: 'Super Iridium'
       },
       comment: '',
       nickname: 'Polsilver - Super Iridium'
@@ -142,7 +142,7 @@ const sampleData = {
         type: 'Boar',
         productType: 'brush',
         brand: 'Surrey',
-        model: '34014 Deluxe',
+        model: '34014 Deluxe'
       },
       comment: '',
       nickname: 'Surrey 34014 Deluxe'
@@ -152,7 +152,7 @@ const sampleData = {
         type: 'Boar',
         productType: 'brush',
         brand: 'Semogue',
-        model: 'Brushbutt 22mm',
+        model: 'Brushbutt 22mm'
       },
       comment: 'Limited Edition #78/100',
       nickname: 'Brushbutt LE'
@@ -162,7 +162,7 @@ const sampleData = {
         type: 'Synthetic',
         productType: 'brush',
         brand: 'RazoRock',
-        model: 'Plissoft Monster',
+        model: 'Plissoft Monster'
       },
       comment: '',
       nickname: 'RazoRock Plissoft Monster'
@@ -172,7 +172,7 @@ const sampleData = {
         type: 'Synthetic',
         productType: 'brush',
         brand: 'Turtleship Shave Co',
-        model: 'Admiral Blue',
+        model: 'Admiral Blue'
       },
       comment: '24mm',
       nickname: 'TSC Admiral Blue 24mm'
@@ -182,7 +182,7 @@ const sampleData = {
         type: 'Badger',
         productType: 'brush',
         brand: 'Kent',
-        model: 'BK8',
+        model: 'BK8'
       },
       comment: '',
       nickname: 'Kent BK8'
@@ -192,7 +192,7 @@ const sampleData = {
         type: 'Badger',
         productType: 'brush',
         brand: 'Stirling Soap Company',
-        model: 'Finest Badger Shave Brush',
+        model: 'Finest Badger Shave Brush'
       },
       comment: '26mm',
       nickname: 'Stirling Badger'
@@ -204,7 +204,7 @@ const sampleData = {
         type: 'Soap',
         productType: 'lather',
         brand: 'Stirling Soap Company',
-        model: 'Barbershop',
+        model: 'Barbershop'
       },
       comment: '',
       nickname: 'Stirling\'s Barbershop'
@@ -214,7 +214,7 @@ const sampleData = {
         type: 'Cream',
         productType: 'lather',
         brand: 'L\'Occitane',
-        model: 'Cade',
+        model: 'Cade'
       },
       comment: '',
       nickname: 'L\'Occitane Cade Rich'
@@ -224,7 +224,7 @@ const sampleData = {
         type: 'Soap',
         productType: 'lather',
         brand: 'Chiseled Face',
-        model: 'Cryogen',
+        model: 'Cryogen'
       },
       comment: 'sampler',
       nickname: 'Chiseled Face Cryogen'
@@ -234,7 +234,7 @@ const sampleData = {
         type: 'Soap',
         productType: 'lather',
         brand: 'Barrister and Mann',
-        model: 'Lavanille',
+        model: 'Lavanille'
       },
       comment: 'tre Citta Line',
       nickname: 'B&M Lavanille'
@@ -244,7 +244,7 @@ const sampleData = {
         type: 'Soap',
         productType: 'lather',
         brand: 'Barrister and Mann',
-        model: 'Leviathan',
+        model: 'Leviathan'
       },
       comment: 'leather | coffee | sandalwood',
       nickname: 'B&M Leviathan'
@@ -254,7 +254,7 @@ const sampleData = {
         type: 'Cream',
         productType: 'lather',
         brand: 'Proraso',
-        model: 'Green',
+        model: 'Green'
       },
       comment: 'horrible, no slickness',
       nickname: 'Proraso Green'
@@ -264,7 +264,7 @@ const sampleData = {
         type: 'Cream',
         productType: 'lather',
         brand: 'Above the Tie',
-        model: 'Lavendar & Lemonade',
+        model: 'Lavendar & Lemonade'
       },
       comment: 'awesome',
       nickname: 'ATT Lemonade'
@@ -274,7 +274,7 @@ const sampleData = {
         type: 'Soap',
         productType: 'lather',
         brand: 'Barrister and Mann',
-        model: 'Roam',
+        model: 'Roam'
       },
       comment: 'Tobacco | Thyme | Grass | Damp Earth | Wood Smoke',
       nickname: 'B&M Roam'
@@ -284,7 +284,7 @@ const sampleData = {
         type: 'Soap',
         productType: 'lather',
         brand: 'Black Ship Grooming',
-        model: 'Captain Joe',
+        model: 'Captain Joe'
       },
       comment: '',
       nickname: 'Black Ship Grooming Captain Joe'
@@ -294,7 +294,7 @@ const sampleData = {
         type: 'Soap',
         productType: 'lather',
         brand: 'Declaration Grooming',
-        model: 'Reserve Lavender',
+        model: 'Reserve Lavender'
       },
       comment: '',
       nickname: 'Declaration Grooming - Reserve Lavender'
@@ -306,7 +306,7 @@ const sampleData = {
         type: 'Splash',
         productType: 'aftershave',
         brand: 'Brut',
-        model: 'Classic',
+        model: 'Classic'
       },
       comment: '',
       nickname: 'Brut Classic'
@@ -316,7 +316,7 @@ const sampleData = {
         type: 'Splash',
         productType: 'aftershave',
         brand: 'Chatillon Lux',
-        model: 'Taum Sauk',
+        model: 'Taum Sauk'
       },
       comment: '',
       nickname: 'CL-Taum Sauk'
@@ -326,7 +326,7 @@ const sampleData = {
         type: 'Splash',
         productType: 'aftershave',
         brand: 'Barrister and Mann',
-        model: 'Lavanille',
+        model: 'Lavanille'
       },
       comment: '',
       nickname: 'Lavanille Splash'
@@ -336,7 +336,7 @@ const sampleData = {
         type: 'Splash',
         productType: 'aftershave',
         brand: 'Barrister and Mann',
-        model: 'Leviathan',
+        model: 'Leviathan'
       },
       comment: '',
       nickname: 'Leviathan Splash'
@@ -346,7 +346,7 @@ const sampleData = {
         type: 'Balm',
         productType: 'aftershave',
         brand: 'Stirling Soap Company',
-        model: 'Sandalwood',
+        model: 'Sandalwood'
       },
       comment: '',
       nickname: 'Stirling Sandalwood Balm'
@@ -356,7 +356,7 @@ const sampleData = {
         type: 'Balm',
         productType: 'aftershave',
         brand: 'Black Ship Grooming',
-        model: 'Captain Joe',
+        model: 'Captain Joe'
       },
       comment: '',
       nickname: 'Black Ship Grooming Captain Joe'
@@ -368,7 +368,7 @@ const sampleData = {
         type: null,
         productType: 'additionalcare',
         brand: 'Proraso',
-        model: 'Green',
+        model: 'Green'
       },
       comment: '',
       nickname: 'Proraso Green'
@@ -378,7 +378,7 @@ const sampleData = {
         type: null,
         productType: 'additionalcare',
         brand: 'Thayers',
-        model: 'Witch Hazel',
+        model: 'Witch Hazel'
       },
       comment: '',
       nickname: 'Thayers Witch Hazel'
@@ -388,7 +388,7 @@ const sampleData = {
         type: null,
         productType: 'additionalcare',
         brand: 'Stirling Soap Company',
-        model: 'Red Delicious - Bath Soap',
+        model: 'Red Delicious - Bath Soap'
       },
       comment: '',
       nickname: 'Stirling Red Delicious Bath Soap'

--- a/models/product.js
+++ b/models/product.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 
 const ProductSchema = new mongoose.Schema({
   type: String,
-  productType: { type: String, enum: ['razor', 'blade', 'brush', 'lather', 'aftershave', 'additonalcare']},
+  productType: { type: String, enum: ['razor', 'blade', 'brush', 'lather', 'aftershave', 'additionalcare']},
   brand: String,
   model: String,
 });

--- a/models/shave.js
+++ b/models/shave.js
@@ -2,12 +2,12 @@ const mongoose = require('mongoose');
 
 const ShaveSchema = new mongoose.Schema({
   userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
-  razorId: { type: mongoose.Schema.Types.ObjectId, ref: 'Product' },
-  bladeId: { type: mongoose.Schema.Types.ObjectId, ref: 'Product' },
-  brushId: { type: mongoose.Schema.Types.ObjectId, ref: 'Product' },
-  latherId: { type: mongoose.Schema.Types.ObjectId, ref: 'Product' },
-  aftershaveId: { type: mongoose.Schema.Types.ObjectId, ref: 'Product' },
-  additionalCare: { type: mongoose.Schema.Types.ObjectId, ref: 'Product' },
+  razorId: { type: mongoose.Schema.Types.ObjectId, ref: 'UserProduct.razors' },
+  bladeId: { type: mongoose.Schema.Types.ObjectId, ref: 'UserProduct.blades' },
+  brushId: { type: mongoose.Schema.Types.ObjectId, ref: 'ProUserProduct.brushes' },
+  latherId: { type: mongoose.Schema.Types.ObjectId, ref: 'UserProduct.lathers' },
+  aftershaveId: { type: mongoose.Schema.Types.ObjectId, ref: 'UserProduct.aftershaves' },
+  additionalCareId: { type: mongoose.Schema.Types.ObjectId, ref: 'UserProduct.additionalcares' },
   rating: Number,
   date: { type:Date, required:true }
 });

--- a/models/user.js
+++ b/models/user.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const mongoose = require('mongoose');
 const bcrypt = require('bcryptjs');
 
@@ -17,8 +19,7 @@ const UserSchema = new mongoose.Schema({
   },
   password: {
     type: String,
-    required: true,
-    unique: true
+    required: true
   },
   email: {
     type: String,

--- a/utils/hash-password.js
+++ b/utils/hash-password.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const bcrypt = require('bcryptjs');
+const password = 'wicked';
+
+/* Hash a password with cost-factor 10, then run compare to verify */
+bcrypt.hash(password, 10)
+  .then(digest => {
+    console.log('digest: ', digest);
+    return digest;
+  })
+  .then(hash => {
+    return bcrypt.compare(password, hash);
+  })
+  .then(valid => {
+    console.log('isValid: ', valid);
+  })
+  .catch(err => {
+    console.error('error: ', err);
+  });

--- a/utils/seed-database.js
+++ b/utils/seed-database.js
@@ -1,0 +1,67 @@
+'use strict';
+
+// npm packages
+require('dotenv').config();
+const mongoose = require('mongoose');
+
+// config
+const { DATABASE_URL } = require('../config');
+
+// models
+const User = require('../models/user');
+const Product = require('../models/product');
+const UserProduct = require('../models/userProduct');
+const Shave = require('../models/shave');
+
+// seed data
+const seedUsers = require('../db/seed/users');
+const seedProducts = require('../db/seed/products');
+const seedUserProducts = require('../db/seed/user-products');
+const seedShaves = require('../db/seed/shaves');
+
+console.log(`Connecting to mongodb at ${DATABASE_URL}`);
+mongoose.connect(DATABASE_URL, { useNewUrlParser: true })
+  .then(() => {
+    console.info('Dropping Database');
+    return mongoose.connection.db.dropDatabase();
+  })
+  .then(() => {
+    console.info('Seeding Database');
+    return Promise.all([
+      User.insertMany(seedUsers),
+      User.createIndexes(),
+
+      Product.insertMany(seedProducts),
+      Product.createIndexes(),
+
+      UserProduct.insertMany(seedUserProducts),
+      UserProduct.createIndexes(),
+
+      Shave.insertMany(seedShaves),
+      Shave.createIndexes()
+    ]);
+  })
+  .then(([
+    users,
+    usersIndexes,
+    products,
+    productsIndexes,
+    userProducts,
+    userProductsIndexes,
+    shaves,
+    shavesIndexes]) => {
+    console.info('Disconnecting');
+    console.info('users: ', users.length);
+    console.info('usersIndexes: ', usersIndexes);
+    console.info('products: ', products.length);
+    console.info('productsIndexes: ', productsIndexes);
+    console.info('userProducts: ', userProducts);
+    console.info('userProductsIndexes: ', userProductsIndexes);
+    console.info('shaves: ', shaves.length);
+    console.info('shavesIndexes: ', shavesIndexes);
+    return mongoose.disconnect();
+  })
+  .catch(err => {
+    console.error(err);
+    return mongoose.disconnect();
+  });

--- a/utils/seed-database.js
+++ b/utils/seed-database.js
@@ -41,26 +41,26 @@ mongoose.connect(DATABASE_URL, { useNewUrlParser: true })
       Shave.createIndexes()
     ]);
   })
-  .then(([
-    users,
-    usersIndexes,
-    products,
-    productsIndexes,
-    userProducts,
-    userProductsIndexes,
-    shaves,
-    shavesIndexes]) => {
-    console.info('Disconnecting');
-    console.info('users: ', users.length);
-    console.info('usersIndexes: ', usersIndexes);
-    console.info('products: ', products.length);
-    console.info('productsIndexes: ', productsIndexes);
-    console.info('userProducts: ', userProducts);
-    console.info('userProductsIndexes: ', userProductsIndexes);
-    console.info('shaves: ', shaves.length);
-    console.info('shavesIndexes: ', shavesIndexes);
-    return mongoose.disconnect();
-  })
+  .then(
+    ([
+      users,
+      usersIndexes,
+      products,
+      productsIndexes,
+      userProducts,
+      userProductsIndexes,
+      shaves,
+      shavesIndexes
+    ]) => {
+      
+      console.info(`Inserted ${users.length} users`);
+      console.info(`Inserted ${products.length} products`);
+      console.info(`Inserted ${userProducts.length} userProducts objects`);
+      console.info(`Inserted ${shaves.length} shaves`);
+
+      console.info('Disconnecting');
+      return mongoose.disconnect();
+    })
   .catch(err => {
     console.error(err);
     return mongoose.disconnect();


### PR DESCRIPTION
This branch adds realistic seed data for all models and a seed-database utility to quickly tear down and repopulate a clean database.

It also:
- fixes a typo in the Product schema
- updates the `ref` values in the Shave schema to point to ids from the UserProduct schema to allow shaves to reference a user's custom metadata around the products used
- removes the uniqueness requirement on the User password field to allow more than one user to have the same password (required for seed users to be properly created)